### PR TITLE
fix: apply AI temperature correctly and switch outputs of model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 */Logs/*
 */*DS_Store
 *DS_Store
+**/.vscode/
+**/UserSettings/


### PR DESCRIPTION
Applied the AI temperature parameter properly by rebuilding the inference graph after level selection using `m_AIDifficultyTemperature`.

Also swapped the ONNX model outputs (as in #20).